### PR TITLE
Update docs for open source

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -50,8 +50,7 @@ jobs:
 
     - name: Verify format
       run: |
-        make fmt
-        git diff --exit-code
+        make lint
 
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
       env:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -51,6 +51,7 @@ jobs:
     - name: Verify format
       run: |
         make lint
+        git diff --exit-code
 
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
       env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+**Table of Contents**
+
+- [Contributing guidelines](#contributing-guidelines)
+    - [Terms](#terms)
+    - [Certificate of Origin](#certificate-of-origin)
+    - [Contributing a patch](#contributing-a-patch)
+    - [Issue and pull request management](#issue-and-pull-request-management)
+    - [Pre-check before submitting a PR](#pre-check-before-submitting-a-pr)
+
+# Contributing guidelines
+
+## Terms
+
+All contributions to the repository must be submitted under the terms of the [Apache Public License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Certificate of Origin
+
+By contributing to this project, you agree to the Developer Certificate of Origin (DCO). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the [DCO](DCO) file for details.
+
+## Contributing a patch
+
+1. Submit an issue describing your proposed change to the repository in question. The repository owners will respond to your issue promptly.
+2. Fork the desired repository, then develop and test your code changes.
+3. Submit a pull request.
+
+## Issue and pull request management
+
+Anyone can comment on issues and submit reviews for pull requests. In order to be assigned an issue or pull request, you can leave a `/assign <your Github ID>` comment on the issue or pull request (PR).
+
+## Pre-check before submitting a PR 
+<!-- Customize this template for your repository -->
+
+Before submitting a PR, please perform the following steps:
+
+- Run steps in [Steps for test](README.md#steps-for-test) in order to verify that:
+    - Code has been properly linted
+    - Unit and E2E tests are passing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,6 @@ By contributing to this project, you agree to the Developer Certificate of Origi
 Anyone can comment on issues and submit reviews for pull requests. In order to be assigned an issue or pull request, you can leave a `/assign <your Github ID>` comment on the issue or pull request (PR).
 
 ## Pre-check before submitting a PR 
-<!-- Customize this template for your repository -->
 
 Before submitting a PR, please perform the following steps:
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,38 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,15 @@ GOARCH = $(shell go env GOARCH)
 GOOS = $(shell go env GOOS)
 # Handle KinD configuration
 KIND_NAME ?= test-managed
-KIND_NAMESPACE ?= multicluster-endpoint
+CONTROLLER_NAMESPACE ?= multicluster-endpoint
 KIND_VERSION ?= latest
 ifneq ($(KIND_VERSION), latest)
 	KIND_ARGS = --image kindest/node:$(KIND_VERSION)
 else
 	KIND_ARGS =
 endif
+# KubeBuilder configuration
+KBVERSION := 2.3.1
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
@@ -42,9 +44,9 @@ fmt vet generate go-coverage
 
 all: test manager
 
-dependencies: dependencies-go
-	curl -sL https://go.kubebuilder.io/dl/2.0.0-alpha.1/${GOOS}/${GOARCH} | tar -xz -C /tmp/
-	sudo mv /tmp/kubebuilder_2.0.0-alpha.1_${GOOS}_${GOARCH} /usr/local/kubebuilder
+############################################################
+# build, run
+############################################################
 
 dependencies-go:
 	go mod tidy
@@ -53,42 +55,35 @@ dependencies-go:
 build:
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -a -tags netgo -o ./build/_output/bin/cert-policy-controller ./cmd/manager
 
+# Run against the current locally configured Kubernetes cluster
+run:
+	go run ./cmd/manager/main.go
+
+############################################################
+# deploy
+############################################################
+
 build-images:
 	@docker build -t ${IMAGE_NAME_AND_VERSION} -f ./Dockerfile .
 	@docker tag ${IMAGE_NAME_AND_VERSION} $(REGISTRY)/$(IMG):$(TAG)
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet
-	go run ./cmd/manager/main.go
+# Install necessary resources into a cluster
+deploy:
+	kubectl apply -f deploy/
+	kubectl apply -f deploy/crds/
 
-# Install CRDs into a cluster
-install: manifests
-	kubectl apply -f config/crds
+############################################################
+# lint
+############################################################
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests
-	kubectl apply -f config/crds
-	kustomize build config/default | kubectl apply -f -
-
-# Generate manifests e.g. CRD, RBAC etc.
-manifests:
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
-
-# Run go fmt against code
-fmt:
+# Lint code
+lint:
 	go fmt ./pkg/... ./cmd/...
+	git diff --exit-code
 
 # Run go vet against code
 vet:
 	go vet ./pkg/... ./cmd/...
-
-test:
-	go test ./...
-
-test-dependencies:
-	curl -L https://go.kubebuilder.io/dl/2.3.0/$(GOOS)/$(GOARCH) | tar -xz -C /tmp/
-	sudo mv /tmp/kubebuilder_2.3.0_$(GOOS)_$(GOARCH) /usr/local/kubebuilder
-	export PATH=$PATH:/usr/local/kubebuilder/bin
 
 # Generate code
 generate:
@@ -97,37 +92,42 @@ generate:
 copyright-check:
 	./build/copyright-check.sh $(TRAVIS_BRANCH) $(TRAVIS_PULL_REQUEST_BRANCH)
 
-# e2e test section
+############################################################
+# unit test
+############################################################
+
+test:
+	go test ./...
+
+test-dependencies:
+	curl -L https://go.kubebuilder.io/dl/$(KBVERSION)/$(GOOS)/$(GOARCH) | tar -xz -C /tmp/
+	sudo mv /tmp/kubebuilder_$(KBVERSION)_$(GOOS)_$(GOARCH) /usr/local/kubebuilder
+
+############################################################
+# e2e test (using KinD clusters)
+############################################################
+
 .PHONY: kind-bootstrap-cluster
 kind-bootstrap-cluster: kind-create-cluster install-crds kind-deploy-controller install-resources
 
 .PHONY: kind-bootstrap-cluster-dev
 kind-bootstrap-cluster-dev: kind-create-cluster install-crds install-resources
 
-check-env:
-ifndef DOCKER_USER
-	$(error DOCKER_USER is undefined)
-endif
-ifndef DOCKER_PASS
-	$(error DOCKER_PASS is undefined)
-endif
-
-kind-deploy-controller: check-env
+kind-deploy-controller:
 	@echo installing $(IMG)
-	kubectl create ns multicluster-endpoint
-	kubectl create secret -n multicluster-endpoint docker-registry multiclusterhub-operator-pull-secret --docker-server=quay.io --docker-username=${DOCKER_USER} --docker-password=${DOCKER_PASS}
-	kubectl apply -f deploy/ -n multicluster-endpoint
+	kubectl create ns $(CONTROLLER_NAMESPACE)
+	kubectl apply -f deploy/ -n $(CONTROLLER_NAMESPACE)
 
 kind-deploy-controller-dev:
 	@echo Pushing image to KinD cluster
 	kind load docker-image $(REGISTRY)/$(IMG):$(TAG) --name $(KIND_NAME)
 	@echo Installing $(IMG)
-	kubectl create ns $(KIND_NAMESPACE)
-	kubectl apply -f deploy/ -n $(KIND_NAMESPACE)
+	kubectl create ns $(CONTROLLER_NAMESPACE)
+	kubectl apply -f deploy/ -n $(CONTROLLER_NAMESPACE)
 	@echo "Patch deployment image"
-	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"imagePullPolicy\":\"Never\"}]}}}}"
-	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"image\":\"$(REGISTRY)/$(IMG):$(TAG)\"}]}}}}"
-	kubectl rollout status -n $(KIND_NAMESPACE) deployment $(IMG) --timeout=180s
+	kubectl patch deployment $(IMG) -n $(CONTROLLER_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"imagePullPolicy\":\"Never\"}]}}}}"
+	kubectl patch deployment $(IMG) -n $(CONTROLLER_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"image\":\"$(REGISTRY)/$(IMG):$(TAG)\"}]}}}}"
+	kubectl rollout status -n $(CONTROLLER_NAMESPACE) deployment $(IMG) --timeout=180s
 
 kind-create-cluster:
 	@echo "creating cluster"
@@ -153,8 +153,8 @@ e2e-dependencies:
 	go get github.com/onsi/gomega/...
 
 e2e-debug:
-	kubectl get all -n $(KIND_NAMESPACE)
+	kubectl get all -n $(CONTROLLER_NAMESPACE)
 	kubectl get all -n managed
 	kubectl get certificatepolicies.policy.open-cluster-management.io --all-namespaces
-	kubectl describe pods -n $(KIND_NAMESPACE)
-	kubectl logs $$(kubectl get pods -n $(KIND_NAMESPACE) -o name | grep $(IMG)) -n $(KIND_NAMESPACE)
+	kubectl describe pods -n $(CONTROLLER_NAMESPACE)
+	kubectl logs $$(kubectl get pods -n $(CONTROLLER_NAMESPACE) -o name | grep $(IMG)) -n $(CONTROLLER_NAMESPACE)

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
 
 ## Usage
 
-In general, the controller is deployed to a namespace, `CONTROLLER_NAMESPACE`, and monitors one namepace, `WATCH_NAMESPACE`, for `CertificatePolicy` resources.
-
 ### Steps for development
 
   - Build code
@@ -57,7 +55,7 @@ In general, the controller is deployed to a namespace, `CONTROLLER_NAMESPACE`, a
     export WATCH_NAMESPACE=<namespace>
     make run
     ```
-    (`WATCH_NAMESPACE` can be any namespace on the cluster that you want to monitor for policies)
+    (`WATCH_NAMESPACE` can be any namespace on the cluster that you want the controller to monitor for policies.)
 
 ### Steps for deployment
 
@@ -72,20 +70,23 @@ In general, the controller is deployed to a namespace, `CONTROLLER_NAMESPACE`, a
       export TAG=''       # (defaults to 'latest')
       ```
   - Deploy controller to a cluster
+
+    The controller is deployed to a namespace defined in `CONTROLLER_NAMESPACE` and monitors the namepace defined in `WATCH_NAMESPACE` for `CertificatePolicy` resources.
+
     1. Create the deployment namespaces
        ```bash
        make create-ns
        ```
-      - The deployment namespaces are configurable with:
-        ```bash
-        export CONTROLLER_NAMESPACE=''  # (defaults to 'multicluster-endpoint')
-        export WATCH_NAMESPACE=''       # (defaults to 'managed')
-        ```
+       The deployment namespaces are configurable with:
+       ```bash
+       export CONTROLLER_NAMESPACE=''  # (defaults to 'multicluster-endpoint')
+       export WATCH_NAMESPACE=''       # (defaults to 'managed')
+       ```
     2. Deploy the controller and related resources
        ```bash
        make deploy
        ```
-    - **NOTE:** Please be aware of the community's [deployment images](https://github.com/open-cluster-management/community#deployment-images) special note.
+    **NOTE:** Please be aware of the community's [deployment images](https://github.com/open-cluster-management/community#deployment-images) special note.
 
 ### Steps for test
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 [comment]: # ( Copyright Contributors to the Open Cluster Management project )
 
-# Certificate Policy Controller [![KinD tests](https://github.com/open-cluster-management/cert-policy-controller/actions/workflows/kind.yml/badge.svg?branch=main&event=push)](https://github.com/open-cluster-management/cert-policy-controller/actions/workflows/kind.yml)
+# Certificate Policy Controller
+
+[![KinD tests](https://github.com/open-cluster-management/cert-policy-controller/actions/workflows/kind.yml/badge.svg?branch=main&event=push)](https://github.com/open-cluster-management/cert-policy-controller/actions/workflows/kind.yml) [![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+
 ## Description
-A controller that watches certificatepolicies created to monitor a kubernetes cluster to ensure certificates don't expire within a given amount of time. The controller shows whether or not a given `CertificatePolicy` is compliant.
-In addition to checking the expiration of certificates, several optional checks are also available.
+
+The Certificate Policy Controller is a controller that watches `CertificatePolicies` created to monitor a Kubernetes cluster to ensure all certificates in given namespaces will not expire within a given amount of time. The `CertificatePolicy` is the Custom Resource Definition (CRD), created for this controller to monitor. The controller can be run as a stand-alone program or as an integrated part of governing risk with Red Hat Advanced Cluster Management for Kubernetes.
+
+In addition to checking the expiration of certificates, several optional checks are also available:
 
 | Field | Description |
 | ---- | ---- |
@@ -14,13 +19,7 @@ In addition to checking the expiration of certificates, several optional checks 
 | allowedSANPattern | Optional: A regular expression that must match every SAN entry you have defined in your certificates. See Golang Regular Expression syntax for more inforamtion: https://golang.org/pkg/regexp/syntax/ |
 | disallowedSANPattern | Optional: A regular expression that must not match any SAN entries you have defined in your certificates.  See Golang Regular Expression syntax for more inforamtion: https://golang.org/pkg/regexp/syntax/ |
 
-
-## Usage
-The controller can be run as a stand-alone program or as an integrated part of governing risk with Red Hat Advanced Cluster Management for Kubernetes.
-
-`CertificatePolicy` is the custom resource definition created by this controller. It watches specific namespaces and shows whether or not those namespaces and the policy as a whole is compliant.
-
-The controller watches for `CertificatePolicy` objects in Kubernetes. This is an example spec of a `CertificatePolicy` object:
+This is an example spec of a `CertificatePolicy` object:
 
 ```
 apiVersion: policy.open-cluster-management.io/v1
@@ -40,3 +39,77 @@ spec:
   # minimum duration is the least amount of time the certificate is still valid before it is considered non-compliant
   minimumDuration: 100h
 ```
+
+Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
+
+## Usage
+
+### Steps for development
+
+  - Build code
+    ```bash
+    make build
+    ```
+  - Run controller locally against the Kubernetes cluster currently configured with `kubectl`
+    ```bash
+    export WATCH_NAMESPACE=<namespace>
+    make run
+    ```
+    (`WATCH_NAMESPACE` can be any namespace on the cluster that you want to monitor for policies)
+
+### Steps for deployment
+
+  - Build container image
+    ```bash
+    make build-images
+    ```
+    - The image registry, name, and tag used in the image build, are configurable with:
+      ```bash
+      export REGISTRY=''  # (defaults to 'quay.io/open-cluster-management')
+      export IMG=''       # (defaults to repo name)
+      export TAG=''       # (defaults to 'latest')
+      ```
+  - Deploy controller to a cluster
+    ```bash
+    make deploy
+    ```
+    - The deployment namespace is configurable with:
+      ```bash
+      export CONTROLLER_NAMESPACE=''  # (defaults to 'multicluster-endpoint')
+      ```
+    - **NOTE:** Please be aware of the community's [deployment images](https://github.com/open-cluster-management/community#deployment-images) special note.
+
+### Steps for test
+
+  - Code linting
+    ```bash
+    make lint
+    ```
+  - Unit tests
+    - Install prerequisites
+      ```bash
+      make test-dependencies
+      ```
+    - Run unit tests
+      ```bash
+      make test
+      ```
+  - E2E tests (**NOTE:** Currently there are no E2E tests to run)
+    1. Prerequisites:
+      - [docker](https://docs.docker.com/get-docker/)
+      - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
+    2. Start KinD cluster (make sure Docker is running first)
+      ```bash
+      make kind-bootstrap-cluster-dev
+      ```
+    3. Start the controller locally (see [Steps for development](#steps-for-development))
+    4. Run E2E tests:
+      ```bash
+      export WATCH_NAMESPACE=managed
+      make e2e-test
+      ```
+
+## References
+
+- The `cert-policy-controller` is part of the `open-cluster-management` community. For more information, visit: [open-cluster-management.io](https://open-cluster-management.io).
+- Check the [Security guide](SECURITY.md) if you need to report a security issue.

--- a/README.md
+++ b/README.md
@@ -70,13 +70,19 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
       export TAG=''       # (defaults to 'latest')
       ```
   - Deploy controller to a cluster
-    ```bash
-    make deploy
-    ```
-    - The deployment namespace is configurable with:
-      ```bash
-      export CONTROLLER_NAMESPACE=''  # (defaults to 'multicluster-endpoint')
-      ```
+    1. Create the deployment namespaces
+       ```bash
+       make create-ns
+       ```
+      - The deployment namespaces are configurable with:
+        ```bash
+        export CONTROLLER_NAMESPACE=''  # (defaults to 'multicluster-endpoint')
+        export WATCH_NAMESPACE=''  # (defaults to 'managed')
+        ```
+    2. Deploy the controller and related resources
+       ```bash
+       make deploy
+       ```
     - **NOTE:** Please be aware of the community's [deployment images](https://github.com/open-cluster-management/community#deployment-images) special note.
 
 ### Steps for test
@@ -96,18 +102,18 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
       ```
   - E2E tests (**NOTE:** Currently there are no E2E tests to run)
     1. Prerequisites:
-      - [docker](https://docs.docker.com/get-docker/)
-      - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
+       - [docker](https://docs.docker.com/get-docker/)
+       - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
     2. Start KinD cluster (make sure Docker is running first)
-      ```bash
-      make kind-bootstrap-cluster-dev
-      ```
+       ```bash
+       make kind-bootstrap-cluster-dev
+       ```
     3. Start the controller locally (see [Steps for development](#steps-for-development))
     4. Run E2E tests:
-      ```bash
-      export WATCH_NAMESPACE=managed
-      make e2e-test
-      ```
+       ```bash
+       export WATCH_NAMESPACE=managed
+       make e2e-test
+       ```
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
 
 ## Usage
 
+In general, the controller is deployed to a namespace, `CONTROLLER_NAMESPACE`, and monitors one namepace, `WATCH_NAMESPACE`, for `CertificatePolicy` resources.
+
 ### Steps for development
 
   - Build code
@@ -77,7 +79,7 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
       - The deployment namespaces are configurable with:
         ```bash
         export CONTROLLER_NAMESPACE=''  # (defaults to 'multicluster-endpoint')
-        export WATCH_NAMESPACE=''  # (defaults to 'managed')
+        export WATCH_NAMESPACE=''       # (defaults to 'managed')
         ```
     2. Deploy the controller and related resources
        ```bash


### PR DESCRIPTION
I've attempted to create a reusable template here that we can extend to the other repos (especially the other controllers) in order to lower the entry bar for new contributors of our repos, including consolidating commands into the Makefile for maintainability.

I've also run through the Makefile and tried to make sure everything is working. Unfortunately, the build harness can't quite be removed yet since we're using it in Travis, but everything else I've documented in the README seems to be working for me locally.
