### PR TITLE
Add field validation to the CertificatePolicy CRD

### DIFF
--- a/api/v1/certificatepolicy_types.go
+++ b/api/v1/certificatepolicy_types.go
@@ -33,20 +33,28 @@ const (
 	UnknownCompliancy ComplianceState = "UnknownCompliancy"
 )
 
+// A custom type is required since there is no way to have a kubebuilder marker
+// apply to the items of a slice.
+
+// +kubebuilder:validation:MinLength=1
+type NonEmptyString string
+
 // Target defines the list of namespaces to include/exclude
 type Target struct {
-	Include []string `json:"include,omitempty"`
-	Exclude []string `json:"exclude,omitempty"`
+	Include []NonEmptyString `json:"include,omitempty"`
+	Exclude []NonEmptyString `json:"exclude,omitempty"`
 }
 
 // CertificatePolicySpec defines the desired state of CertificatePolicy
 type CertificatePolicySpec struct {
 	//enforce, inform
+	// +kubebuilder:validation:Enum=Inform;inform;Enforce;enforce
 	RemediationAction RemediationAction `json:"remediationAction,omitempty"`
 	// selecting a list of namespaces where the policy applies
-	NamespaceSelector Target            `json:"namespaceSelector,omitempty"`
-	LabelSelector     map[string]string `json:"labelSelector,omitempty"`
-	// low, medium, or high
+	NamespaceSelector Target                    `json:"namespaceSelector,omitempty"`
+	LabelSelector     map[string]NonEmptyString `json:"labelSelector,omitempty"`
+	// low, medium, high, or critical
+	// +kubebuilder:validation:Enum=low;medium;high;critical
 	Severity string `json:"severity,omitempty"`
 	// Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only
 	MinDuration *metav1.Duration `json:"minimumDuration,omitempty"`
@@ -60,10 +68,12 @@ type CertificatePolicySpec struct {
 	// Golang's time units only
 	MaxCADuration *metav1.Duration `json:"maximumCADuration,omitempty"`
 	// A pattern that must match any defined SAN entries in the certificate for the certificate to be compliant.
-	//  Golang's regexp symtax only
+	//  Golang's regexp syntax only
+	// +kubebuilder:validation:MinLength=1
 	AllowedSANPattern string `json:"allowedSANPattern,omitempty"`
 	// A pattern that must not match any defined SAN entries in the certificate for the certificate to be compliant.
-	// Golang's regexp symtax only
+	// Golang's regexp syntax only
+	// +kubebuilder:validation:MinLength=1
 	DisallowedSANPattern string `json:"disallowedSANPattern,omitempty"`
 }
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -96,7 +96,7 @@ func (in *CertificatePolicySpec) DeepCopyInto(out *CertificatePolicySpec) {
 	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
 	if in.LabelSelector != nil {
 		in, out := &in.LabelSelector, &out.LabelSelector
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]NonEmptyString, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -182,12 +182,12 @@ func (in *Target) DeepCopyInto(out *Target) {
 	*out = *in
 	if in.Include != nil {
 		in, out := &in.Include, &out.Include
-		*out = make([]string, len(*in))
+		*out = make([]NonEmptyString, len(*in))
 		copy(*out, *in)
 	}
 	if in.Exclude != nil {
 		in, out := &in.Exclude, &out.Exclude
-		*out = make([]string, len(*in))
+		*out = make([]NonEmptyString, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -39,15 +39,18 @@ spec:
               allowedSANPattern:
                 description: A pattern that must match any defined SAN entries in
                   the certificate for the certificate to be compliant.  Golang's regexp
-                  symtax only
+                  syntax only
+                minLength: 1
                 type: string
               disallowedSANPattern:
                 description: A pattern that must not match any defined SAN entries
                   in the certificate for the certificate to be compliant. Golang's
-                  regexp symtax only
+                  regexp syntax only
+                minLength: 1
                 type: string
               labelSelector:
                 additionalProperties:
+                  minLength: 1
                   type: string
                 type: object
               maximumCADuration:
@@ -71,18 +74,30 @@ spec:
                 properties:
                   exclude:
                     items:
+                      minLength: 1
                       type: string
                     type: array
                   include:
                     items:
+                      minLength: 1
                       type: string
                     type: array
                 type: object
               remediationAction:
                 description: enforce, inform
+                enum:
+                - Inform
+                - inform
+                - Enforce
+                - enforce
                 type: string
               severity:
-                description: low, medium, or high
+                description: low, medium, high, or critical
+                enum:
+                - low
+                - medium
+                - high
+                - critical
                 type: string
             type: object
           status:

--- a/pkg/common/namespace_selection.go
+++ b/pkg/common/namespace_selection.go
@@ -11,17 +11,19 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1 "github.com/open-cluster-management/cert-policy-controller/api/v1"
 )
 
 //=================================================================
 // GetSelectedNamespaces returns the list of filtered namespaces according to the policy namespace selector
-func GetSelectedNamespaces(included, excluded, allNamespaces []string) []string {
+func GetSelectedNamespaces(included, excluded []policyv1.NonEmptyString, allNamespaces []string) []string {
 	//get all namespaces
 	//allNamespaces := getAllNamespaces() //TODO change this to call the func
 	//then get the list of included
 	includedNamespaces := []string{}
 	for _, value := range included {
-		found := FindPattern(value, allNamespaces)
+		found := FindPattern(string(value), allNamespaces)
 		if found != nil {
 			includedNamespaces = append(includedNamespaces, found...)
 		}
@@ -30,7 +32,7 @@ func GetSelectedNamespaces(included, excluded, allNamespaces []string) []string 
 	//then get the list of excluded
 	excludedNamespaces := []string{}
 	for _, value := range excluded {
-		found := FindPattern(value, allNamespaces)
+		found := FindPattern(string(value), allNamespaces)
 		if found != nil {
 			excludedNamespaces = append(excludedNamespaces, found...)
 		}

--- a/pkg/common/namespace_selection_test.go
+++ b/pkg/common/namespace_selection_test.go
@@ -32,6 +32,8 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	policiesv1 "github.com/open-cluster-management/cert-policy-controller/api/v1"
 )
 
 var c client.Client
@@ -70,8 +72,8 @@ func TestCreateNamespace(t *testing.T) {
 func TestGetSelectedNamespaces(t *testing.T) {
 	// testing the actual logic
 	allNamespaces := []string{"default", "dev-accounting", "dev-HR", "dev-research", "kube-public", "kube-sys"}
-	included := []string{"dev-*", "kube-*", "default"}
-	excluded := []string{"dev-research", "kube-sys"}
+	included := []policiesv1.NonEmptyString{"dev-*", "kube-*", "default"}
+	excluded := []policiesv1.NonEmptyString{"dev-research", "kube-sys"}
 	expectedResult := []string{"default", "dev-accounting", "dev-HR", "kube-public"}
 	actualResutl := GetSelectedNamespaces(included, excluded, allNamespaces)
 	if len(expectedResult) != len(actualResutl) {

--- a/pkg/common/synced_map_utils_test.go
+++ b/pkg/common/synced_map_utils_test.go
@@ -46,8 +46,8 @@ var plc = &policiesv1.CertificatePolicy{
 	Spec: policiesv1.CertificatePolicySpec{
 		RemediationAction: policiesv1.Enforce,
 		NamespaceSelector: policiesv1.Target{
-			Include: []string{"default"},
-			Exclude: []string{"kube*"},
+			Include: []policiesv1.NonEmptyString{"default"},
+			Exclude: []policiesv1.NonEmptyString{"kube*"},
 		},
 	},
 }


### PR DESCRIPTION
This specifically targeted the user-facing fields.

Most field validation occurs client and server side except for unknown
fields. That is handled only on the client side validation. This is
enabled by default with `kubectl`, however, `oc` requires `--validate=true`
to be set. When an unknown field is provided with client side validation
disabled, the server will ignore it (default for v1 CRDs) and not store
the unknown field in etcd.

Note that `additionalProperties: false` cannot be set on objects which have
the `properties` validation. This is a restriction by Kubernetes. The
workaround is setting `spec.preserveUnknownFields: false` (default for
v1 CRDs) and having client side validation enabled.

Resolves:
https://github.com/open-cluster-management/backlog/issues/17096