### PR TITLE
Add back the regex validation for CRD duration fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,9 @@ KUSTOMIZE = $(shell pwd)/bin/kustomize
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 .PHONY: manifests
-manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=cert-policy-controller paths="./..." output:crd:artifacts:config=deploy/crds output:rbac:artifacts:config=deploy/rbac
+manifests: controller-gen kustomize
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=cert-policy-controller paths="./..." output:crd:artifacts:config=deploy/crds/kustomize output:rbac:artifacts:config=deploy/rbac
+	$(KUSTOMIZE) build deploy/crds/kustomize > deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/v1/duration_pattern_test.go
+++ b/api/v1/duration_pattern_test.go
@@ -1,0 +1,46 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package v1_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+// Tests that the pattern in deploy/crds/kustomize/patches.json is valid.
+// When updating that file, also update these tests.
+const durationPattern = "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
+
+func TestPattern(t *testing.T) {
+	t.Parallel()
+	regex := regexp.MustCompile(durationPattern)
+
+	tests := []struct {
+		duration string
+		expected bool
+	}{
+		{"1h", true},
+		{"1.5h", true},
+		{"1.h", false},
+		{"2h45m30s", true},
+		{"-2h45m", false},
+		{"1m3ms", true},
+		{"1us", true},
+		{"2ns", true},
+		{"1.5.3h", false},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(
+			fmt.Sprintf("duration=%s,expected=%v", test.duration, test.expected),
+			func(t *testing.T) {
+				result := regex.Match([]byte(test.duration))
+				if test.expected != result {
+					t.Fatalf("expected %v, got %v", test.expected, result)
+				}
+			},
+		)
+	}
+}

--- a/deploy/crds/kustomize/kustomization.yaml
+++ b/deploy/crds/kustomize/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - policy.open-cluster-management.io_certificatepolicies.yaml
+
+# Use patches to add field validation that Kubebuilder markers can't
+patches:
+- path: patches.json
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: certificatepolicies.policy.open-cluster-management.io

--- a/deploy/crds/kustomize/patches.json
+++ b/deploy/crds/kustomize/patches.json
@@ -1,0 +1,23 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumCADuration/pattern",
+        "value": "^[0-9][0-9hmnsu.]+"
+
+    },
+    {
+        "op": "add",
+        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumDuration/pattern",
+        "value": "^[0-9][0-9hmnsu.]+"
+    },
+    {
+        "op": "add",
+        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumCADuration/pattern",
+        "value": "^[0-9][0-9hmnsu.]+"
+    },
+    {
+        "op": "add",
+        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumDuration/pattern",
+        "value": "^[0-9][0-9hmnsu.]+"
+    }
+]

--- a/deploy/crds/kustomize/patches.json
+++ b/deploy/crds/kustomize/patches.json
@@ -2,22 +2,22 @@
     {
         "op": "add",
         "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumCADuration/pattern",
-        "value": "^[0-9][0-9hmnsu.]+"
+        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
 
     },
     {
         "op": "add",
         "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumDuration/pattern",
-        "value": "^[0-9][0-9hmnsu.]+"
+        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
     },
     {
         "op": "add",
         "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumCADuration/pattern",
-        "value": "^[0-9][0-9hmnsu.]+"
+        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
     },
     {
         "op": "add",
         "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumDuration/pattern",
-        "value": "^[0-9][0-9hmnsu.]+"
+        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
     }
 ]

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20,10 +22,14 @@ spec:
         description: CertificatePolicy is the Schema for the certificatepolicies API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -31,11 +37,15 @@ spec:
             description: CertificatePolicySpec defines the desired state of CertificatePolicy
             properties:
               allowedSANPattern:
-                description: A pattern that must match any defined SAN entries in the certificate for the certificate to be compliant.  Golang's regexp syntax only
+                description: A pattern that must match any defined SAN entries in
+                  the certificate for the certificate to be compliant.  Golang's regexp
+                  syntax only
                 minLength: 1
                 type: string
               disallowedSANPattern:
-                description: A pattern that must not match any defined SAN entries in the certificate for the certificate to be compliant. Golang's regexp syntax only
+                description: A pattern that must not match any defined SAN entries
+                  in the certificate for the certificate to be compliant. Golang's
+                  regexp syntax only
                 minLength: 1
                 type: string
               labelSelector:
@@ -44,20 +54,20 @@ spec:
                   type: string
                 type: object
               maximumCADuration:
-                description: Maximum CA duration for a signing certificate, longer duration is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                description: Maximum CA duration for a signing certificate, longer
+                  duration is considered non-compliant. Golang's time units only
                 type: string
               maximumDuration:
-                description: Maximum duration for a certificate, longer duration is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                description: Maximum duration for a certificate, longer duration is
+                  considered non-compliant. Golang's time units only
                 type: string
               minimumCADuration:
-                description: Minimum CA duration before a signing certificate expires that it is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                description: Minimum CA duration before a signing certificate expires
+                  that it is considered non-compliant. Golang's time units only
                 type: string
               minimumDuration:
-                description: Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                description: Minimum duration before a certificate expires that it
+                  is considered non-compliant. Golang's time units only
                 type: string
               namespaceSelector:
                 description: selecting a list of namespaces where the policy applies
@@ -95,24 +105,32 @@ spec:
             properties:
               compliancyDetails:
                 additionalProperties:
-                  description: CompliancyDetails defines the all the details related to whether or not the policy is compliant
+                  description: CompliancyDetails defines the all the details related
+                    to whether or not the policy is compliant
                   properties:
                     NonCompliantCertificates:
                       type: integer
                     NonCompliantCertificatesList:
                       additionalProperties:
-                        description: Cert contains its related secret and when it expires
+                        description: Cert contains its related secret and when it
+                          expires
                         properties:
                           ca:
                             type: boolean
                           duration:
-                            description: A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
                             format: int64
                             type: integer
                           expiration:
                             type: string
                           expiry:
-                            description: A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
                             format: int64
                             type: integer
                           sans:

--- a/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -45,19 +45,19 @@ spec:
                 type: object
               maximumCADuration:
                 description: Maximum CA duration for a signing certificate, longer duration is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               maximumDuration:
                 description: Maximum duration for a certificate, longer duration is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               minimumCADuration:
                 description: Minimum CA duration before a signing certificate expires that it is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               minimumDuration:
                 description: Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only
-                pattern: ^[0-9][0-9hmnsu.]+
+                pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               namespaceSelector:
                 description: selecting a list of namespaces where the policy applies


### PR DESCRIPTION
This was accidentally removed in 07b5116c. Since the `Pattern`
Kubebuilder marker can only be set on strings, some Kustomize hackery
had to be used instead.

The second commit is to make the duration pattern stricter.