### PR TITLE
Fix a typo in the NonCompliantCertificatesList tag

### DIFF
--- a/api/v1/certificatepolicy_types.go
+++ b/api/v1/certificatepolicy_types.go
@@ -88,7 +88,7 @@ type CertificatePolicyStatus struct {
 // CompliancyDetails defines the all the details related to whether or not the policy is compliant
 type CompliancyDetails struct {
 	NonCompliantCertificates     uint            `json:"NonCompliantCertificates,omitempty"`
-	NonCompliantCertificatesList map[string]Cert `json:"NonCompliantCertificatesList,omitEmpty"`
+	NonCompliantCertificatesList map[string]Cert `json:"NonCompliantCertificatesList,omitempty"`
 	Message                      string          `json:"message,omitempty"` // Overall message of this compliance
 }
 

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -143,8 +143,6 @@ spec:
                       type: object
                     message:
                       type: string
-                  required:
-                  - NonCompliantCertificatesList
                   type: object
                 description: map of namespaces to its compliancy details
                 type: object

--- a/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -125,8 +125,6 @@ spec:
                       type: object
                     message:
                       type: string
-                  required:
-                  - NonCompliantCertificatesList
                   type: object
                 description: map of namespaces to its compliancy details
                 type: object


### PR DESCRIPTION
This accidentally made NonCompliantCertificatesList required but it
should not be.